### PR TITLE
Fixes #9: 'WSGIRequest' object has no attribute 'get_raw_uri'

### DIFF
--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -155,10 +155,8 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         # TODO: Cache this!
         application = get_application_model().objects.get(client_id=credentials["client_id"])
 
-        uri_query = urllib.parse.urlparse(self.request.get_raw_uri()).query
-        uri_query_params = dict(
-            urllib.parse.parse_qsl(uri_query, keep_blank_values=True, strict_parsing=False)
-        )
+        uri_query = django_http_request.parse_qsl(django_http_request.urlsplit(request.get_full_path()).query)
+        uri_query_params = dict(uri_query)
 
         kwargs["application"] = application
         kwargs["client_id"] = credentials["client_id"]

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -20,6 +20,7 @@ from ..scopes import get_scopes_backend
 from ..settings import oauth2_settings
 from ..signals import app_authorized
 from .mixins import OAuthLibMixin
+from django.http import request as django_http_request
 
 
 log = logging.getLogger("oauth2_provider")


### PR DESCRIPTION
Django Version: 	4.2.9
Exception Type: 	AttributeError
Exception Value: 	

'WSGIRequest' object has no attribute 'get_raw_uri'

Exception Location: 	/usr/local/lib/python3.10/dist-packages/oauth2_provider/views/base.py, line 158, in get
Raised during: 	oauth2_provider.views.base.AuthorizationView
Python Executable: 	/usr/local/bin/uwsgi